### PR TITLE
fix: remove support for inline partials

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,19 +237,6 @@ Partial metadata can be accessed using the `@partial` variable inside the partia
 - `@partial.attributes`: the custom data provided to the partial (if any).
 - `@partial.context`: the current rendering context.
 
-### Inline partials
-
-> Added in `v0.28.0`.
-
-Inline partials allows you to define partials directly in your template. Use `>*` followed by the partial name to start the partial definition, and end the partial definition with a slash `/` followed by the partial name. For example, `{{>*foo}}` begins a partial definition called `foo`, and `{{/foo}}` ends it.
-
-Example:
-
-```javascript
-const result = m(`{{>*foo}}Hello {{name}}!{{/foo}}{{>foo name="Bob"}}`, {});
-// Output: 'Hello Bob!'
-```
-
 ### Helpers
 
 > Added in `v0.4.0`.

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,16 +1,17 @@
+export type MikelPartial = {
+    body: string;
+    data: Record<string, any>;
+};
+
 export type MikelHelper = (params: {
     args: any[];
     options: Record<string, any>;
     tokens: string[];
     data: Record<string, any>;
     state: Record<string, any>;
+    partials: Record<string, string | MikelPartial>;
     fn: (blockData?: Record<string, any>, blockState?: Record<string, any>, blockOutput?: string[]) => string;
 }) => string;
-
-export type MikelPartial = {
-    body: string;
-    data: Record<string, any>;
-};
 
 export type MikelFunction = (params: {
     args: any[];

--- a/index.js
+++ b/index.js
@@ -154,10 +154,7 @@ const defaultHelpers = {
         return "";
     },
     "macro": params => {
-        if (typeof params.state.partials === "undefined") {
-            params.state.partials = {};
-        }
-        params.state.partials[params.args[0].trim()] = untokenize(params.tokens).trim();
+        params.partials[params.args[0].trim()] = untokenize(params.tokens).trim();
         return "";
     },
 };
@@ -171,7 +168,7 @@ const create = (options = {}) => {
         state: {},
     });
     // internal method to compile the template
-    const compile = (tokens, output, data, state, index = 0, section = "") => {
+    const compile = (tokens, output, data = {}, state = {}, partials = {}, index = 0, section = "") => {
         let i = index;
         while (i < tokens.length) {
             if (i % 2 === 0) {
@@ -187,6 +184,7 @@ const create = (options = {}) => {
                     tokens: tokens.slice(j, i),
                     data: data,
                     state: state,
+                    partials: partials,
                     fn: (blockData = {}, customBlockState = {}, blockOutput = []) => {
                         const blockState = {
                             ...state,
@@ -200,7 +198,7 @@ const create = (options = {}) => {
                             parent: data,
                             root: state.root,
                         };
-                        compile(tokens, blockOutput, blockData, blockState, j, t);
+                        compile(tokens, blockOutput, blockData, blockState, partials, j, t);
                         return blockOutput.join("");
                     },
                 }));
@@ -212,20 +210,19 @@ const create = (options = {}) => {
                 if (!negate && value && Array.isArray(value)) {
                     const j = i + 1;
                     (value.length > 0 ? value : [""]).forEach(item => {
-                        i = compile(tokens, value.length > 0 ? output : [], item, state, j, t);
+                        i = compile(tokens, value.length > 0 ? output : [], item, state, partials, j, t);
                     });
                 }
                 else {
                     const includeOutput = (!negate && !!value) || (negate && !!!value);
-                    i = compile(tokens, includeOutput ? output : [], data, state, i + 1, t);
+                    i = compile(tokens, includeOutput ? output : [], data, state, partials, i + 1, t);
                 }
             }
             else if (tokens[i].startsWith(">")) {
                 const [t, args, opt] = parseArgs(tokens[i].replace(/^>{1,2}/, ""), data, state);
                 const blockContent = []; // to store partial block content
-                const partials = Object.assign({}, ctx.partials, state.partials || {});
                 if (tokens[i].startsWith(">>")) {
-                    i = compile(tokens, blockContent, data, state, i + 1, t);
+                    i = compile(tokens, blockContent, data, state, partials, i + 1, t);
                 }
                 if (typeof partials[t] === "string" || typeof partials[t]?.body === "string") {
                     const partialBody = partials[t]?.body || partials[t];
@@ -241,7 +238,7 @@ const create = (options = {}) => {
                             context: partialData,
                         },
                     };
-                    compile(tokenize(partialBody), output, partialData, partialState, 0, "");
+                    compile(tokenize(partialBody), output, partialData, partialState, partials, 0, "");
                 }
             }
             else if (tokens[i].startsWith("=")) {
@@ -270,7 +267,7 @@ const create = (options = {}) => {
     };
     // entry method to compile the template with the provided data object
     const compileTemplate = (template, data = {}, output = []) => {
-        compile(tokenize(template), output, data, { root: data, ...ctx.state }, 0, "");
+        compile(tokenize(template), output, data, { root: data, ...ctx.state }, { ...ctx.partials }, 0, "");
         return output.join("");
     };
     // assign api methods and return method to compile the template

--- a/index.js
+++ b/index.js
@@ -220,17 +220,6 @@ const create = (options = {}) => {
                     i = compile(tokens, includeOutput ? output : [], data, state, i + 1, t);
                 }
             }
-            // DEPRECATED
-            else if (tokens[i].startsWith(">*")) {
-                const t = tokens[i].slice(2).trim(), partialTokens = tokens.slice(i + 1);
-                const lastIndex = partialTokens.findIndex((token, j) => {
-                    return j % 2 !== 0 && token.trim().startsWith("/") && token.trim().endsWith(t);
-                });
-                if (typeof ctx.partials[t] === "undefined") {
-                    ctx.partials[t] = untokenize(partialTokens.slice(0, lastIndex));
-                }
-                i = i + lastIndex + 1;
-            }
             else if (tokens[i].startsWith(">")) {
                 const [t, args, opt] = parseArgs(tokens[i].replace(/^>{1,2}/, ""), data, state);
                 const blockContent = []; // to store partial block content

--- a/test.js
+++ b/test.js
@@ -214,21 +214,6 @@ describe("templating", () => {
         });
     });
 
-    describe("{{>* xyz}}", () => {
-        const template = `{{>*foo}}Hello {{name}}!{{/foo}}{{>foo name="Bob"}}`;
-
-        it("should allow to define inline partials", () => {
-            assert.equal(m(template, {}), "Hello Bob!");
-        });
-
-        it("should not overwrite user partials", () => {
-            const partials = {
-                foo: "Hola {{name}}!",
-            };
-            assert.equal(m(template, {}, {partials}), "Hola Bob!");
-        });
-    });
-
     describe("{{#each }}", () => {
         it("should do nothing if value is not an array or object", () => {
             assert.equal(m("x{{#each values}}{{.}}{{/each}}x", {values: null}), "xx");


### PR DESCRIPTION
Use `{{#macro }}` helper instead