### PR TITLE
refactor!: drop support for inline partials

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,19 +237,6 @@ Partial metadata can be accessed using the `@partial` variable inside the partia
 - `@partial.attributes`: the custom data provided to the partial (if any).
 - `@partial.context`: the current rendering context.
 
-### Inline partials
-
-> Added in `v0.28.0`.
-
-Inline partials allows you to define partials directly in your template. Use `>*` followed by the partial name to start the partial definition, and end the partial definition with a slash `/` followed by the partial name. For example, `{{>*foo}}` begins a partial definition called `foo`, and `{{/foo}}` ends it.
-
-Example:
-
-```javascript
-const result = m(`{{>*foo}}Hello {{name}}!{{/foo}}{{>foo name="Bob"}}`, {});
-// Output: 'Hello Bob!'
-```
-
 ### Helpers
 
 > Added in `v0.4.0`.
@@ -448,6 +435,8 @@ console.log(m(template, {})); // --> 'Hello Bob!'
 Macros can be executed using the `#call` helper.
 
 #### call
+
+> Added in `v0.33.0`.
 
 The `call` helper allows you to execute registered macros. Key-value arguments will be passed as a data to the content inside the macro:
 

--- a/index.js
+++ b/index.js
@@ -172,33 +172,21 @@ const compile = (ctx, tokens, output, data, state, index = 0, section = "") => {
                 i = compile(ctx, tokens, includeOutput ? output : [], data, state, i + 1, t);
             }
         }
-        // DEPRECATED
-        else if (tokens[i].startsWith(">*")) {
-            const t = tokens[i].slice(2).trim(), partialTokens = tokens.slice(i + 1);
-            const lastIndex = partialTokens.findIndex((token, j) => {
-                return j % 2 !== 0 && token.trim().startsWith("/") && token.trim().endsWith(t);
-            });
-            if (typeof ctx.partials[t] === "undefined") {
-                ctx.partials[t] = untokenize(partialTokens.slice(0, lastIndex));
-            }
-            i = i + lastIndex + 1;
-        }
         else if (tokens[i].startsWith(">")) {
             const [t, args, opt] = parseArgs(tokens[i].replace(/^>{1,2}/, ""), data, state);
             const blockContent = []; // to store partial block content
-            const partials = Object.assign({}, ctx.partials, state.partials || {});
             if (tokens[i].startsWith(">>")) {
                 i = compile(ctx, tokens, blockContent, data, state, i + 1, t);
             }
-            if (typeof partials[t] === "string" || typeof partials[t]?.body === "string") {
-                const partialBody = partials[t]?.body || partials[t];
+            if (typeof ctx.partials[t] === "string" || typeof ctx.partials[t]?.body === "string") {
+                const partialBody = ctx.partials[t]?.body || ctx.partials[t];
                 const partialData = args.length > 0 ? args[0] : (Object.keys(opt).length > 0 ? opt : data);
                 const partialState = {
                     ...state,
                     content: blockContent.join(""),
                     partial: {
                         name: t,
-                        attributes: partials[t]?.attributes || partials[t]?.data || {},
+                        attributes: ctx.partials[t]?.attributes || ctx.partials[t]?.data || {},
                         args: args || [],
                         options: opt || {},
                         context: partialData,

--- a/test.js
+++ b/test.js
@@ -205,27 +205,12 @@ describe("templating", () => {
     });
 
     describe("{{>> xyz}}", () => {
-        it("should allow providing a block to the partial", () => {
+        it("should allow to prove a block of content to the partial", () => {
             const partials = {
                 foo: "Hello {{@content}}!",
             };
 
             assert.equal(m("{{>>foo}}Bob{{/foo}}", {}, {partials}), "Hello Bob!");
-        });
-    });
-
-    describe("{{>* xyz}}", () => {
-        const template = `{{>*foo}}Hello {{name}}!{{/foo}}{{>foo name="Bob"}}`;
-
-        it("should allow to define inline partials", () => {
-            assert.equal(m(template, {}), "Hello Bob!");
-        });
-
-        it("should not overwrite user partials", () => {
-            const partials = {
-                foo: "Hola {{name}}!",
-            };
-            assert.equal(m(template, {}, {partials}), "Hola Bob!");
         });
     });
 


### PR DESCRIPTION
Use `{{#macro}}` and `{{#call}}` helpers instead